### PR TITLE
Use keys in Subutai client for creating environments and ssh connections to containers

### DIFF
--- a/chop/amazon/src/main/java/org/apache/usergrid/chop/api/store/amazon/EC2InstanceManager.java
+++ b/chop/amazon/src/main/java/org/apache/usergrid/chop/api/store/amazon/EC2InstanceManager.java
@@ -117,7 +117,6 @@ public class EC2InstanceManager implements InstanceManager {
      * @param timeout   in milliseconds, if smaller than <code>getDefaultTimeout()</code> it doesn't wait
      * @return          resulting runner instances which successfully got in Running state
      */
-    @Override
     public LaunchResult launchCluster( ICoordinatedStack stack, ICoordinatedCluster cluster, int timeout ) {
 
         RunInstancesResult runInstancesResult = null;
@@ -187,6 +186,13 @@ public class EC2InstanceManager implements InstanceManager {
         Collection<Instance> instances = toInstances( getEC2Instances( instanceIds ) );
 
         return new EC2LaunchResult( cluster.getInstanceSpec(), instances );
+    }
+
+
+    @Override
+    public LaunchResult launchCluster( final ICoordinatedStack stack, final ICoordinatedCluster cluster,
+                                       final int timeout, final String publicKeyFilePath ) {
+        return launchCluster( stack, cluster, timeout );
     }
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Job.java
@@ -119,14 +119,12 @@ public class Job implements Callable<ResponseInfo> {
         // try to open ssh session
         String userName = Utils.SUBUTAI_USER;
         try {
-            // TODO is this really necessary??
-//            Thread.sleep( 30000 );
             ssh = new JSch();
-            // TODO replace password with ssh key file as you see below when Subutai has key management
-//            ssh.addIdentity( value.getSshKeyFile() );
+            ssh.addIdentity( value.getSshKeyFile() );
             session = ssh.getSession( userName, value.getPublicIpAddress() );
             session.setConfig( "StrictHostKeyChecking", "no" );
-            session.setPassword( "ubuntu" );
+            // TODO remove this when default non-root user can execute sudo commands without password in Subutai
+//            session.setPassword( "ubuntu" );
             session.connect();
         }
         catch ( Exception e ) {
@@ -163,16 +161,18 @@ public class Job implements Callable<ResponseInfo> {
         String message;
         try {
             channel = session.openChannel( "exec" );
-            // Append "sudo -S -p '' echo" so that if sudo asks for password, eliminate password prompt
-            // by doing it in the beginning
-            if ( value.getProviderName().equals( SubutaiProvider.PROVIDER_NAME ) ) {
-                ( ( ChannelExec ) channel ).setCommand( "echo " + Utils.DEFAULT_SUBUTAI_PASSWORD
-                        + " | sudo -S -p '' echo > /dev/null && "
-                        + command.getCommand() );
-            }
-            else {
-                ( ( ChannelExec ) channel ).setCommand( command.getCommand() );
-            }
+            // TODO remove this commented block when default non-root user can execute sudo commands without password in Subutai
+////            Append "sudo -S -p '' echo" so that if sudo asks for password, eliminate password prompt
+////            by doing it in the beginning
+//            if ( value.getProviderName().equals( SubutaiProvider.PROVIDER_NAME ) ) {
+//                ( ( ChannelExec ) channel ).setCommand( "echo " + Utils.DEFAULT_SUBUTAI_PASSWORD
+//                        + " | sudo -S -p '' echo > /dev/null && "
+//                        + command.getCommand() );
+//            }
+//            else {
+//                ( ( ChannelExec ) channel ).setCommand( command.getCommand() );
+//            }
+            ( ( ChannelExec ) channel ).setCommand( command.getCommand() );
             channel.connect();
 
             BufferedReader inputReader = new BufferedReader( new InputStreamReader( channel.getInputStream() ) );

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Utils.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/ssh/Utils.java
@@ -26,8 +26,9 @@ import java.io.InputStream;
 public class Utils {
 
     public static final String DEFAULT_USER = "ubuntu";
-    public static final String SUBUTAI_USER = "subutai";
-    public static final String DEFAULT_SUBUTAI_PASSWORD = "ubuntu";
+    public static final String SUBUTAI_USER = "root";
+    // TODO remove this when default non-root user can execute sudo commands without password in Subutai
+    //    public static final String DEFAULT_SUBUTAI_PASSWORD = "ubuntu";
 
 
     public static String checkAck( InputStream in ) throws IOException {

--- a/chop/spi/src/main/java/org/apache/usergrid/chop/spi/InstanceManager.java
+++ b/chop/spi/src/main/java/org/apache/usergrid/chop/spi/InstanceManager.java
@@ -37,7 +37,8 @@ public interface InstanceManager {
 
     void terminateInstances( Collection<String> instanceIds );
 
-    LaunchResult launchCluster( ICoordinatedStack stack, ICoordinatedCluster cluster, int timeout );
+    LaunchResult launchCluster( ICoordinatedStack stack,
+                                ICoordinatedCluster cluster, int timeout, String publicKeyFilePath );
 
     LaunchResult launchRunners( ICoordinatedStack stack, InstanceSpec spec, int timeout );
 

--- a/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiClient.java
+++ b/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiClient.java
@@ -26,7 +26,6 @@ import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.representation.Form;
-import com.sun.jersey.api.uri.UriComponent;
 import org.apache.usergrid.chop.api.RestParams;
 import org.apache.usergrid.chop.stack.Cluster;
 import org.apache.usergrid.chop.stack.ICoordinatedCluster;
@@ -44,7 +43,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,7 +86,27 @@ public class SubutaiClient
      * @param stack used to create an environment on Subutai
      * @return the environment created for the given stack
      */
-    public EnvironmentJson createStackEnvironment( final ICoordinatedStack stack ) {
+    public EnvironmentJson createStackEnvironment( final ICoordinatedStack stack, File publicKeyFile ) {
+
+        String publicKeyFileContent;
+        if( publicKeyFile == null  ) {
+            LOG.error( "File cannot be null! Aborting.." );
+            return null;
+        }
+        if ( ! publicKeyFile.exists() ) {
+            LOG.error( "File {} does not exist! Aborting..", publicKeyFile );
+            return null;
+        }
+
+        try {
+            byte[] encoded = Files.readAllBytes( Paths.get( publicKeyFile.getAbsolutePath() ) );
+            publicKeyFileContent = new String( encoded );
+        }
+        catch ( IOException e ) {
+            LOG.error( "Could not read file {}! Error: {}", publicKeyFile.getAbsoluteFile(), e.getMessage() );
+            return null;
+        }
+
         // Create the topology from the supplied stack
         TopologyJson topology = getTopologyFromStack( stack );
 
@@ -92,9 +116,7 @@ public class SubutaiClient
         // Returns the uuid of the environment created from the supplied topology
         Form environmentCreateForm = new Form();
         environmentCreateForm.add( RestParams.ENVIRONMENT_TOPOLOGY, gson.toJson( topology ) );
-        // TODO set the environment ssh key when it works on Subutai
-        environmentCreateForm.add( RestParams.SSH_KEY, gson.toJson( null ) );
-        environmentCreateForm.add( RestParams.SSH_KEY, "{}" );
+        environmentCreateForm.add( RestParams.SSH_KEY, publicKeyFileContent );
 
         ClientResponse environmentBuildResponse = resource.type( MediaType.APPLICATION_FORM_URLENCODED_TYPE )
                                                           .accept( MediaType.APPLICATION_JSON )

--- a/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiClient.java
+++ b/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiClient.java
@@ -234,7 +234,6 @@ public class SubutaiClient
         Form addContainerToExistingEnvironmentForm = new Form();
         addContainerToExistingEnvironmentForm.add( RestParams.ENVIRONMENT_ID, environmentId.toString() );
         addContainerToExistingEnvironmentForm.add( RestParams.ENVIRONMENT_TOPOLOGY, gson.toJson( runnerTopology ) );
-        // TODO set the environment ssh key when it works on Subutai
         addContainerToExistingEnvironmentForm.add( RestParams.SSH_KEY, null );
 
         ClientResponse addNodeGroupResponse = resource.path( "/grow" )

--- a/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiInstanceManager.java
+++ b/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiInstanceManager.java
@@ -32,6 +32,7 @@ import org.safehaus.subutai.core.env.rest.EnvironmentJson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,14 +142,23 @@ public class SubutaiInstanceManager implements InstanceManager
 
     @Override
     public LaunchResult launchCluster( final ICoordinatedStack stack, final ICoordinatedCluster cluster,
-                                       final int timeout )
+                                       final int timeout, final String publicKeyFilePath )
     {
         LOG.info( "Creating the cluster instances on {}", stack.getDataCenter() );
 
         List<String> instanceIds = new ArrayList<String>( cluster.getSize() );
         Collection<Instance> instances = new ArrayList<Instance>();
         // Create the environment
-        EnvironmentJson environment = subutaiClient.createStackEnvironment( stack );
+        if ( publicKeyFilePath == null ) {
+            LOG.error( "Public key file path cannot be null!" );
+            return new SubutaiLaunchResult( cluster.getInstanceSpec(), Collections.EMPTY_LIST );
+        }
+        File publicKeyFile = new File( publicKeyFilePath );
+        if ( ! publicKeyFile.exists() ) {
+            LOG.error( "Public key {} does not exists!", publicKeyFilePath );
+            return new SubutaiLaunchResult( cluster.getInstanceSpec(), Collections.EMPTY_LIST );
+        }
+        EnvironmentJson environment = subutaiClient.createStackEnvironment( stack, publicKeyFile );
 
         if ( environment == null ) {
             LOG.error( "Could not create environment for {} stack!", stack.getName() );

--- a/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiUtils.java
+++ b/chop/subutai/src/main/java/org/apache/usergrid/chop/api/store/subutai/SubutaiUtils.java
@@ -122,4 +122,7 @@ public class SubutaiUtils
     }
 
 
+    public static String getPublicKeyFileName( String privateKeyName ) {
+        return privateKeyName + ".pub";
+    }
 }

--- a/chop/subutai/src/test/java/org/apache/usergrid/chop/api/store/subutai/TestSubutaiClient.java
+++ b/chop/subutai/src/test/java/org/apache/usergrid/chop/api/store/subutai/TestSubutaiClient.java
@@ -154,7 +154,7 @@ public class TestSubutaiClient
         mockClusterEnvironmentJson = new EnvironmentJson( environmentId, stack.getName(),
                 EnvironmentStatus.HEALTHY, clusterContainers );
 
-        /**  */
+        /** Create a temporary key file necessary for creating environment on Subutai */
         String publicKeyFileName = SubutaiUtils.getPublicKeyFileName( cluster.getInstanceSpec().getKeyName() );
         File file = folder.newFile( publicKeyFileName );
         publicKeyFile = file;

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/CoordinatorUtils.java
@@ -228,6 +228,7 @@ public class CoordinatorUtils {
         Collection<SshValues> sshValues = new HashSet<SshValues>( cluster.getSize() );
         StringBuilder sb = new StringBuilder();
         Collection<Command> commands = new ArrayList<Command>();
+        String userHomeDirectory;
 
         LOG.info( "Starting the execution of setup scripts on cluster {}", cluster.getName() );
 
@@ -246,6 +247,13 @@ public class CoordinatorUtils {
                 sshValues.add( new AmazonInstanceValues( instance, keyFile ) );
             }
             username = Utils.DEFAULT_USER;
+        }
+
+        if ( username.equals( "root" ) ) {
+            userHomeDirectory = "/root";
+        }
+        else {
+            userHomeDirectory = "/home/" + username;
         }
 
         // Prepare setup environment variables
@@ -316,8 +324,7 @@ public class CoordinatorUtils {
 
             /** SCP the script to instance **/
             sb = new StringBuilder();
-            sb.append( "/home/" )
-              .append( username )
+            sb.append( userHomeDirectory )
               .append( "/" )
               .append( fileToSave.getName() );
 
@@ -327,8 +334,7 @@ public class CoordinatorUtils {
             /** calling chmod first just in case **/
             sb = new StringBuilder();
             sb.append( "chmod 0755 " )
-              .append( "/home/" )
-              .append( username )
+              .append( userHomeDirectory )
               .append( "/" )
               .append( fileToSave.getName() )
               .append( ";" );
@@ -357,6 +363,7 @@ public class CoordinatorUtils {
         Collection<SshValues> sshValues = new HashSet<SshValues>( stack.getRunnerCount() );
         StringBuilder sb = new StringBuilder();
         Collection<Command> commands = new ArrayList<Command>();
+        String userHomeDirectory;
 
         LOG.info( "Deploying and starting runner.jar to runner instances of {}", stack.getName() );
 
@@ -377,9 +384,15 @@ public class CoordinatorUtils {
             username = Utils.DEFAULT_USER;
         }
 
+        if ( username.equals( "root" ) ) {
+            userHomeDirectory = "/root";
+        }
+        else {
+            userHomeDirectory = "/home/" + username;
+        }
+
         /** SCP the runner.jar to instance **/
-        sb.append( "/home/" )
-          .append( username )
+        sb.append( userHomeDirectory )
           .append( "/" )
           .append( runnerJar.getName() );
 
@@ -414,10 +427,9 @@ public class CoordinatorUtils {
 
                 /** SCP the script to instance **/
                 sb = new StringBuilder();
-                sb.append( "/home/" )
-                        .append( username )
-                        .append( "/" )
-                        .append( fileToSave.getName() );
+                sb.append( userHomeDirectory )
+                  .append( "/" )
+                  .append( fileToSave.getName() );
 
                 String destinationFile = sb.toString();
                 commands.add( new SCPCommand( fileToSave.getAbsolutePath(), destinationFile ) );
@@ -425,8 +437,7 @@ public class CoordinatorUtils {
                 /** calling chmod first just in case **/
                 sb = new StringBuilder();
                 sb.append( "chmod 0755 " )
-                        .append( "/home/" )
-                        .append( username )
+                        .append( userHomeDirectory )
                         .append( "/" )
                         .append( fileToSave.getName() )
                         .append( ";" );

--- a/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/SetupStackThread.java
+++ b/chop/webapp/src/main/java/org/apache/usergrid/chop/webapp/coordinator/SetupStackThread.java
@@ -139,7 +139,7 @@ public class SetupStackThread implements Callable<CoordinatedStack> {
                 String publicKeyFileName = SubutaiUtils.getPublicKeyFileName( cluster.getInstanceSpec().getKeyName() );
                 publicKeyFilePath = providerParams.getKeys().get( publicKeyFileName );
                 if ( publicKeyFilePath == null ) {
-                    errorMessage = "No key found with name " + cluster.getInstanceSpec().getKeyName() +
+                    errorMessage = "No key found with name " + publicKeyFileName +
                             " for cluster " + cluster.getName();
                     LOG.warn( errorMessage + ", aborting and terminating launched instances..." );
                     instanceManager.terminateInstances( launchedInstances );


### PR DESCRIPTION
As Subutai added a support to create environment via a provided public key, this PR provides following changes:
- Create stack instances on Subutai via a provided public key by user whose name should have ".pub" at the end (i.e. if the private key name is TestKeyPair, then the public key name should be TestKeyPair.pub )
- Create ssh connections to Subutai instances via provided private key by user instead of via default password.