### PR TITLE
Import runner certificates to coordinator instance

### DIFF
--- a/chop/api/src/main/java/org/apache/usergrid/chop/api/ChopUtils.java
+++ b/chop/api/src/main/java/org/apache/usergrid/chop/api/ChopUtils.java
@@ -102,16 +102,9 @@ public class ChopUtils {
     }
 
 
-    public static boolean isTrusted( String hostname ) {
-        synchronized ( lock ) {
-            return trustedHosts.contains( hostname );
-        }
-    }
-
-
     public static boolean isTrusted( Runner runner ) {
         synchronized ( lock ) {
-            return trustedHosts.contains( runner.getHostname() );
+            return trustedHosts.contains( runner.getHostname() ) || trustedHosts.contains( runner.getIpv4Address() );
         }
     }
 
@@ -295,6 +288,9 @@ public class ChopUtils {
 
         LOG.debug( "cert = {}", cert );
         LOG.debug( "Added certificate to keystore 'jssecacerts' using alias '" + host + "'" );
+        synchronized ( lock ) {
+            trustedHosts.add( host );
+        }
     }
 
 

--- a/chop/api/src/main/java/org/apache/usergrid/chop/api/ChopUtils.java
+++ b/chop/api/src/main/java/org/apache/usergrid/chop/api/ChopUtils.java
@@ -322,7 +322,7 @@ public class ChopUtils {
 
 
         public X509Certificate[] getAcceptedIssuers() {
-            throw new UnsupportedOperationException();
+            return new X509Certificate[0];
         }
 
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
@@ -66,7 +66,7 @@ public class RestRequests {
                                     runner.getHostname(), runner.getIpv4Address() )  );
                         }
                         else {
-                            LOG.info( String.format( "Runner %s is verified.", runner.getHostname()  ) );
+                            LOG.debug( String.format( "Runner %s is verified.", runner.getHostname()  ) );
                         }
                         return isVerified;
                     }

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
@@ -66,28 +66,22 @@ public class RestRequests {
                                     runner.getHostname(), runner.getIpv4Address() )  );
                         }
                         else {
-                            LOG.debug( String.format( "Runner %s is verified.", runner.getHostname()  ) );
+                            LOG.info( String.format( "Runner %s is verified.", runner.getHostname()  ) );
                         }
                         return isVerified;
                     }
                 } );
 
         if ( ! ChopUtils.isTrusted( runner ) ) {
-            try {
-                ChopUtils.installRunnerKey( null, runner );
-            }
-            catch ( Exception e ) {
-                LOG.error( "Failed to install certificate for runner: {}", runner.getHostname() );
-
                 try {
-                    ChopUtils.installCert( runner.getHostname(), runner.getServerPort(), null );
+                    ChopUtils.installCert( runner.getIpv4Address(), runner.getServerPort(), null );
                 }
-                catch ( Exception e2 ) {
+                catch ( Exception e ) {
                     LOG.error( "Failed to get certificate from server {} on port {}: dumping stack trace!",
                             runner.getHostname(), runner.getServerPort() );
                     e.printStackTrace();
                 }
-            }
+//            }
         }
     }
 

--- a/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
+++ b/chop/client/src/main/java/org/apache/usergrid/chop/client/rest/RestRequests.java
@@ -81,7 +81,6 @@ public class RestRequests {
                             runner.getHostname(), runner.getServerPort() );
                     e.printStackTrace();
                 }
-//            }
         }
     }
 


### PR DESCRIPTION
With this pull request, Chop coordinator imports certificates of runner instances into its truststore.