### PR TITLE
Temporary fix for missing guice-servlet dependency inside runner.jar file

### DIFF
--- a/chop/pom.xml
+++ b/chop/pom.xml
@@ -388,6 +388,30 @@
         <version>${subutai.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>javax.sql.rowset</groupId>
+            <artifactId>com.springsource.javax.sql.rowset</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcmail-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpg-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-ext-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>

--- a/chop/subutai-example/pom.xml
+++ b/chop/subutai-example/pom.xml
@@ -43,6 +43,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-servlet</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.fluttercode.datafactory</groupId>
       <artifactId>datafactory</artifactId>
       <version>${datafactory.version}</version>


### PR DESCRIPTION
With this PR, the following problem is resolved temporarily:

https://jira.safehaus.org/browse/SUBUTAI-2963

However, the root cause of this error, runner plugin, should be fixed as described in the above issue.